### PR TITLE
use env python2 instead of env python.

### DIFF
--- a/swig/Makefile.am
+++ b/swig/Makefile.am
@@ -7,20 +7,20 @@ $(builddir)/%_wrap.c %.py: %.i
 
 # Don't interfere with distutils CFLAGS
 _%.$(PYEXT): $(builddir)/%_wrap.c
-	env CFLAGS="" python setup.py build_ext
+	env CFLAGS="" python2 setup.py build_ext
 	cp -v `./copywhich.sh $@` .
 
 clean-local:
 	-@rm -vf mapper.py mapper_wrap.c
-	python setup.py clean --all
+	python2 setup.py clean --all
 
 MOSTLYCLEANFILES = _mapper.$(PYEXT) mapper.py mapper_wrap.c installed_files.log
 
 install-exec-hook: $(builddir)/mapper_wrap.c
 	if test -n "$(DESTDIR)"; then\
-		python setup.py install --root=$(DESTDIR) --prefix=$(prefix) --record=@top_builddir@/swig/installed_files.log; \
+		python2 setup.py install --root=$(DESTDIR) --prefix=$(prefix) --record=@top_builddir@/swig/installed_files.log; \
 	else \
-		python setup.py install --prefix=$(prefix) --record=@top_builddir@/swig/installed_files.log; \
+		python2 setup.py install --prefix=$(prefix) --record=@top_builddir@/swig/installed_files.log; \
 	fi
 
 uninstall-hook:

--- a/swig/copywhich.sh
+++ b/swig/copywhich.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-PYMACHINE="$(python -c 'import platform; print platform.machine()')"
+PYMACHINE="$(python2 -c 'import platform; print platform.machine()')"
 ARCHES="$(ls -d build/lib.*/$1)"
 
 # If the Python platform architecture is found, copy that one

--- a/swig/setup.py.in
+++ b/swig/setup.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 setup.py file for SWIG mapper

--- a/swig/testcallbacks.py
+++ b/swig/testcallbacks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys, mapper
 

--- a/swig/testinstance.py
+++ b/swig/testinstance.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys, mapper, random
 

--- a/swig/testquery.py
+++ b/swig/testquery.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys, mapper
 

--- a/swig/testqueue.py
+++ b/swig/testqueue.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys, mapper, random
 

--- a/swig/testreverse.py
+++ b/swig/testreverse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys, mapper
 

--- a/swig/testvector.py
+++ b/swig/testvector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys, mapper, random
 

--- a/swig/tkgui.py
+++ b/swig/tkgui.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import Tkinter
 import sys


### PR DESCRIPTION
This makes compilation compatible with systems where python 3 and python
2 are both present.
