### PR TITLE
Update python tutorial to use python 3 syntax.

### DIFF
--- a/doc/tutorials/tutorial_python.md
+++ b/doc/tutorials/tutorial_python.md
@@ -299,8 +299,8 @@ def frequency_handler(sig, id, val, timetag):
     try:
         sine.setFreq(val)
     except:
-        print 'exception'
-        print sig, val
+        print('exception')
+        print(sig, val)
 ~~~
 
 Then our program will look like this:
@@ -317,8 +317,8 @@ def freq_handler(sig, id, val, timetag):
     try:
         sine.setFreq(val)
     except:
-        print 'exception'
-        print sig, val
+        print('exception')
+        print(sig, val)
 
 dev = mapper.device('pyo_example')
 dev.add_input_signal('frequency', 1, 'f', 'Hz', 20, 2000, freq_handler)


### PR DESCRIPTION
Closed issue #24 adds python 3 support, but the python tutorial file is still using the python 2 syntax for print statements.

It may be worth updating this document unless python 2 is explicitly preferred by libmapper.  _(python 2 is depreciated as of Jan. 2020)_