### PR TITLE
Build Python wheels using Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,21 +11,40 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: install dependencies
       run: sudo apt-get install g++-8 autoconf-archive curl zlib1g-dev
     - name: install liblo
       run: curl -L -O https://downloads.sourceforge.net/project/liblo/liblo/0.31/liblo-0.31.tar.gz && tar -xzf liblo-0.31.tar.gz && cd liblo-0.31 && (./configure --host=$HOST --prefix=$PWD/inst --enable-static --disable-tests --disable-tools --disable-examples || (cat config.log; false)) && make install && find inst && cd ..
     - name: autogen
-      run: pwd && mkdir $PWD/inst && (./autogen.sh --enable-static --prefix=$PWD/inst PKG_CONFIG_PATH=$PWD/liblo-0.31/inst/lib/pkgconfig || (cat config.log; false))
+      run: pwd && mkdir $PWD/inst && env NOCONFIGURE=1 ./autogen.sh && (./configure --enable-static --prefix=$PWD/inst PKG_CONFIG_PATH=$PWD/liblo-0.31/inst/lib/pkgconfig || (cat config.log; false))
     - name: make
       run: make && (make check || (for i in src/*.log; do echo === $i ===; cat $i; done; false)) && make install && find inst
     - name: make tests
       run: cd test && make tests
+    - name: python wheels
+      run:
+        sudo apt-get -y install python3-pip python3-setuptools python3-venv
+        && python3 -m pip install git+https://github.com/henryiii/cibuildwheel@henryiii/chore/intreebuild
+        && make clean
+        && rm -rf inst liblo-0.31 && tar -xzf liblo-0.31.tar.gz
+        && python3 -m cibuildwheel --output-dir wheelhouse ./swig
+        && ls wheelhouse
+      env:
+        CIBW_BUILD: "cp3*"
+        CIBW_BEFORE_ALL: "yum install -y libtool automake autoconf zlib-devel swig"
+        CIBW_BEFORE_BUILD: "cd {package}; for package in $(pwd); do cd $package/../liblo-0.31 && ./configure --prefix=$package/../inst --disable-shared --enable-static --disable-tests --disable-tools --disable-debug --disable-examples CFLAGS=-fPIC && make clean && make install && cd $package/.. && env NOCONFIGURE=1 ./autogen.sh && ./configure PKG_CONFIG_PATH=$package/../inst/lib/pkgconfig --enable-static --disable-shared --disable-tests --disable-jni --disable-docs --disable-audio --disable-debug CFLAGS=-fPIC && make clean && make -C src && make -C swig mapper_wrap.c; done"
+    - uses: actions/upload-artifact@v2
+      with:
+        path: ./wheelhouse/*.whl
 
   MacOS:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: install dependencies
       run: brew install autoconf-archive automake
     - name: install liblo
@@ -36,11 +55,26 @@ jobs:
       run: make && (make check || (for i in src/*.log; do echo === $i ===; cat $i; done; false)) && make install && find inst
     - name: make tests
       run: cd test && make tests
+    - name: python wheels
+      run:
+        python3 -m pip install git+https://github.com/henryiii/cibuildwheel@henryiii/chore/intreebuild
+        && make clean
+        && rm -rf inst liblo-0.31 && tar -xzf liblo-0.31.tar.gz
+        && python3 -m cibuildwheel --output-dir wheelhouse ./swig
+        && ls wheelhouse
+      env:
+        CIBW_BUILD: "cp3*"
+        CIBW_BEFORE_BUILD: "cd {package}; for package in $(pwd); do cd $package/../liblo-0.31 && ./configure --prefix=$package/../inst --disable-shared --enable-static --disable-tests --disable-tools --disable-debug --disable-examples CFLAGS=-fPIC && make clean && make install && cd $package/.. && env NOCONFIGURE=1 ./autogen.sh && ./configure PKG_CONFIG_PATH=$package/../inst/lib/pkgconfig --enable-static --disable-shared --disable-tests --disable-jni --disable-docs --disable-audio --disable-debug CFLAGS=-fPIC && make clean && make -C src && make -C swig mapper_wrap.c; done"
+    - uses: actions/upload-artifact@v2
+      with:
+        path: ./wheelhouse/*.whl
   
   MinGW:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - name: install dependencies
       run: sudo apt-get install g++-mingw-w64 autoconf-archive curl
     - name: install liblo

--- a/configure.ac
+++ b/configure.ac
@@ -144,34 +144,32 @@ CFLAGS="$_CFLAGS"
 # Check options
 AC_ARG_ENABLE(debug,
    [AS_HELP_STRING([--enable-debug],[compile with debug flags])],
-   enable_debug=yes)
+   enable_debug=$enableval)
 
 AC_ARG_ENABLE(tests,
    [  --disable-tests         don't build test programs.],,
-   enable_tests=yes)
+   enable_tests=$enableval, enable_tests=yes)
 
 AC_ARG_ENABLE(docs,
    [  --disable-docs          don't build the documentation.],,
-   enable_docs=yes)
+   enable_docs=$enableval, enable_docs=yes)
 
 AC_ARG_ENABLE(audio,
    [  --disable-audio         don't build the audio examples.],,
-   enable_audio=yes)
+   enable_audio=$enableval, enable_audio=yes)
 
-swig_enabled=yes
 AC_ARG_ENABLE(swig,
    [  --disable-swig          don't build the SWIG bindings.],
-   swig_enabled=$enableval)
+   enable_swig=$enableval=$enableval, enable_swig=yes)
 
-jni_enabled=yes
 AC_ARG_ENABLE(jni,
    [  --disable-jni          don't build the Java JNI bindings.],
-   jni_enabled=$enableval)
+   enable_jni=$enableval, enable_jni=yes)
 
-if test x$swig_enabled = xyes; then
+if test x$enable_swig = xyes; then
    AC_CHECK_PROG([SWIG], [swig], [swig])
    if test x$SWIG = x; then
-     swig_enabled=no
+     enable_swig=no
      swig_explain="(swig not found)"
    else
      AM_PATH_PYTHON(2.3, [have_python="yes"], [have_python="no"])
@@ -185,14 +183,14 @@ if test x$swig_enabled = xyes; then
        esac
        swig_explain="($(basename $PYTHON)$PY3SWIG)"
      else
-       swig_enabled=no
+       enable_swig=no
        swig_explain="(python not found)"
      fi
    fi
 fi
 
 # Check for JNI
-if test x$jni_enabled = xyes; then
+if test x$enable_jni = xyes; then
    AC_MSG_CHECKING([JDK path])
    if test x"$JAVA_HOME" == "x"; then
       JAVA_HOME="$(dirname $(dirname $(readlink /etc/alternatives/javac 2>/dev/null)))"
@@ -241,22 +239,22 @@ if test x$jni_enabled = xyes; then
    AC_PATH_PROG([JAVAH], [javah], [], ["$JDKBINPATH"$PATH_SEPARATOR$PATH])
    AC_PATH_PROG([JAR],   [jar],   [], ["$JDKBINPATH"$PATH_SEPARATOR$PATH])
    if test x$JAVAC = x; then
-     jni_enabled=no
+     enable_jni=no
      jni_explain="(javac not found)"
    elif test x$JAVAH = x; then
      jni_enabled=no
      jni_explain="(javah not found)"
    elif test x$JAR = x; then
-     jni_enabled=no
+     enable_jni=no
      jni_explain="(jar not found)"
    else
      CFLAGS_revert="$CFLAGS"
      CFLAGS="$CFLAGS $JNIFLAGS"
      AC_CHECK_HEADER([jni.h],
-       [jni_enabled=yes],
-       [jni_enabled=no; jni_explain="(jni.h not found)"])
+       [enable_jni=yes],
+       [enable_jni=no; jni_explain="(jni.h not found)"])
      CFLAGS="$CFLAGS_revert"
-     if test x$jni_enabled = xyes; then
+     if test x$enable_jni = xyes; then
        JNI=jni
        AC_SUBST(JNIFLAGS)
        AC_SUBST(JNI)
@@ -344,7 +342,7 @@ CXXFLAGS="-I. $CXXFLAGS"
 AM_CONDITIONAL(TESTS, test "x$enable_tests" = xyes)
 AM_CONDITIONAL(HAVE_DOXYGEN, test "x$DOXYGEN" != x)
 AM_CONDITIONAL(HAVE_PYTHON, test "x$have_python" = xyes)
-AM_CONDITIONAL(HAVE_SWIG, test "x$swig_enabled" = xyes)
+AM_CONDITIONAL(HAVE_SWIG, test "x$enable_swig" = xyes)
 AM_CONDITIONAL(HAVE_AUDIO, test "x$enable_audio" = xyes)
 
 AC_CONFIG_FILES([
@@ -374,8 +372,8 @@ echo libmapper configured:
 echo --------------------------------------------------
 echo "building documention...    " $enable_docs $docs_explain
 echo "building tests...          " $enable_tests
-echo "building SWIG bindings...  " $swig_enabled $swig_explain
-echo "building Java bindings...  " $jni_enabled $jni_explain
+echo "building SWIG bindings...  " $enable_swig $swig_explain
+echo "building Java bindings...  " $enable_jni $jni_explain
 echo "building audio examples... " $enable_audio $audio_explain
 AS_IF([test x$enable_debug = xyes],
       [echo "Debug flags enabled."])

--- a/configure.ac
+++ b/configure.ac
@@ -236,14 +236,10 @@ if test x$enable_jni = xyes; then
    fi
 
    AC_PATH_PROG([JAVAC], [javac], [], ["$JDKBINPATH"$PATH_SEPARATOR$PATH])
-   AC_PATH_PROG([JAVAH], [javah], [], ["$JDKBINPATH"$PATH_SEPARATOR$PATH])
    AC_PATH_PROG([JAR],   [jar],   [], ["$JDKBINPATH"$PATH_SEPARATOR$PATH])
    if test x$JAVAC = x; then
      enable_jni=no
      jni_explain="(javac not found)"
-   elif test x$JAVAH = x; then
-     jni_enabled=no
-     jni_explain="(javah not found)"
    elif test x$JAR = x; then
      enable_jni=no
      jni_explain="(jar not found)"

--- a/configure.ac
+++ b/configure.ac
@@ -324,6 +324,12 @@ AS_IF([test x$with_liblo != xno],[
   LIBS="$tmpLIBS"
 ])
 
+# If shared is disabled, need to link bindings directly to zlib
+if test x$enable_shared != xyes; then
+  EXTRA_LIBS_BINDINGS=\"z\"
+fi
+AC_SUBST(EXTRA_LIBS_BINDINGS)
+
 # Debug mode
 AS_IF([test x$enable_debug = xyes],
       [CFLAGS="-g -O0 -Wall -Werror -DDEBUG `echo $CFLAGS | sed 's/-O2//'`"

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ(2.61)
 
 m4_define([LIBMAPPER_VERSION],[2.0b])
 AC_INIT([libmapper],
-  [m4_esyscmd_s([test -d .git && git describe --always || echo LIBMAPPER_VERSION])],
+  m4_esyscmd_s([test -d .git && (git describe --tags | sed 's/\([^\-]*\)-\([^\-]*\)-\([^\-]*\)/\1.\2+\3/g') || echo LIBMAPPER_VERSION]),
   [dot_mapper@googlegroups.com],[],[http://libmapper.org])
 
 # libtool version: current:revision:age
@@ -373,4 +373,5 @@ echo "building Java bindings...  " $enable_jni $jni_explain
 echo "building audio examples... " $enable_audio $audio_explain
 AS_IF([test x$enable_debug = xyes],
       [echo "Debug flags enabled."])
+echo "version                    " $PACKAGE_VERSION
 echo --------------------------------------------------

--- a/jni/Makefile.am
+++ b/jni/Makefile.am
@@ -36,7 +36,7 @@ JCLASSESINTERNAL = mapper/Signal$$Instance.class mapper/AbstractObject$$Properti
 JJAVA = $(JCLASSES:%.class=%.java)
 
 BUILT_SOURCES = $(JHEADERS) test.class testinstance.class testreverse.class \
-    testspeed.class libmapper.jar
+    testspeed.class libmapper.jar TestInstances/code/libmapper.jar TestInstances/code/libmapperjni.so
 MOSTLYCLEANFILES = $(BUILT_SOURCES) $(JCLASSES) $(subst $$,\$$,$(JCLASSESINTERNAL)) \
     test*.class
 
@@ -77,11 +77,16 @@ testspeed.class: testspeed.java $(JCLASSES)
 
 libmapper.jar: $(JCLASSES) $(JCLASSESINTERNAL)
 	$(JAR) cvf $@ $(subst $$,\$$,$^)
-	if mkdir -v TestInstances/code; then \
-	  cd TestInstances/code/; \
-	  ln -v -s ../../.libs/*.so .; \
-	  ln -v -s ../../$@; \
-	  fi # For processing test sketch
+
+# For processing test sketch
+TestInstances/code/libmapperjni.so: $(lib_LTLIBRARIES)
+	[ -d TestInstances/code ]	|| mkdir -v TestInstances/code
+	cd TestInstances/code; ls -l; [ -L libmapperjni.so ] || [ -f libmapperjni.so ] || ln -v -s ../../.libs/libmapperjni.so .
+
+# For processing test sketch
+TestInstances/code/libmapper.jar: libmapper.jar
+	[ -d TestInstances/code ]	|| mkdir -v TestInstances/code
+	cd TestInstances/code; ls -l; [ -L libmapperjni.so ] || [ -f libmapperjni.so ] || ln -v -s ../../libmapper.jar
 
 EXTRA_DIST = $(JJAVA) test.java testinstance.java testreverse.java testspeed.java \
              $(JHEADERS)

--- a/swig/Makefile.am
+++ b/swig/Makefile.am
@@ -1,14 +1,14 @@
 
 _CXX =  $(filter-out ccache,$(CXX))
 
-all-local: _mapper.$(PYEXT)
+all-local: _libmapper.$(PYEXT)
 
 $(builddir)/%_wrap.c %.py: %.i
 	$(SWIG) -I$(top_srcdir)/include -python -py3 -modern -o $(builddir)/mapper_wrap.c \
 		$(srcdir)/mapper.i
 
 # Don't interfere with distutils CFLAGS
-_%.$(PYEXT): $(builddir)/%_wrap.c
+_libmapper.$(PYEXT): $(builddir)/mapper_wrap.c
 	env CFLAGS="" CXX="$(_CXX)" $(PYTHON) setup.py build_ext
 	cp -v `@top_srcdir@/swig/copywhich.sh $(PYTHON) $(@:.so=)` .
 
@@ -17,7 +17,7 @@ clean-local:
 	-@rm -vfr build __pycache__
 	$(PYTHON) setup.py clean --all
 
-MOSTLYCLEANFILES = _mapper.$(PYEXT) _mapper.*.$(PYEXT) mapper.py mapper_wrap.c installed_files.log
+MOSTLYCLEANFILES = _libmapper.$(PYEXT) _libmapper.*.$(PYEXT) mapper.py mapper_wrap.c installed_files.log
 
 install-exec-hook: $(builddir)/mapper_wrap.c
 	if test -n "$(DESTDIR)"; then\

--- a/swig/mapper.i
+++ b/swig/mapper.i
@@ -1,4 +1,4 @@
-%module mapper
+%module libmapper
 %include "typemaps.i"
 %typemap(in) PyObject *PyFunc {
     if ($input!=Py_None && !PyCallable_Check($input)) {

--- a/swig/setup.py.in
+++ b/swig/setup.py.in
@@ -15,7 +15,7 @@ LO_INCDIRS = [x[2:] for x in LO_CFLAGS.split() if x[0:2]=='-I']
 
 EXTRA_LIBS = [@EXTRA_LIBS_BINDINGS@]
 
-mapper_module = Extension('_mapper',
+mapper_module = Extension('_libmapper',
                           sources=['mapper_wrap.c'],
                           include_dirs=['@top_srcdir@/src',
                                         '@top_builddir@/src',
@@ -24,7 +24,7 @@ mapper_module = Extension('_mapper',
                           libraries=['mapper'] + LO_LDLIBS + EXTRA_LIBS,
                           )
 
-setup (name = 'mapper',
+setup (name = 'libmapper',
        version = '@PACKAGE_VERSION@',
        author      = "libmapper.org",
        author_email = "dot_mapper@googlegroups.com",
@@ -32,5 +32,5 @@ setup (name = 'mapper',
        description = """A library for mapping controllers and synthesizers.""",
        license = "GNU LGPL version 2.1 or later",
        ext_modules = [mapper_module],
-       py_modules = ["mapper"],
+       py_modules = ["libmapper"],
        )

--- a/swig/setup.py.in
+++ b/swig/setup.py.in
@@ -13,13 +13,15 @@ LO_LDLIBS = [x[2:] for x in LO_LIBS.split() if x[0:2]=='-l']
 LO_CFLAGS = "@liblo_CFLAGS@"
 LO_INCDIRS = [x[2:] for x in LO_CFLAGS.split() if x[0:2]=='-I']
 
+EXTRA_LIBS = [@EXTRA_LIBS_BINDINGS@]
+
 mapper_module = Extension('_mapper',
                           sources=['mapper_wrap.c'],
                           include_dirs=['@top_srcdir@/src',
                                         '@top_builddir@/src',
                                         '@top_srcdir@/include']+LO_INCDIRS,
                           library_dirs=['@top_builddir@/src/.libs']+LO_LDDIRS,
-                          libraries=['mapper']+LO_LDLIBS,
+                          libraries=['mapper'] + LO_LDLIBS + EXTRA_LIBS,
                           )
 
 setup (name = 'mapper',


### PR DESCRIPTION
Build Python wheels using Github Actions.
* Renames Python module to "libmapper"
* Links libz in setup.py when --disable-shared
* Improves cleanup for symlinks from Processing example sketch.
* Changes format of version string to adhere to [PEP440](https://www.python.org/dev/peps/pep-0440/) requirements.
* Remove javah check.
* Fixes usage of AC_ARG_ENABLE in configure.ac.

Does *not* include uploading the wheels to pypi
