### PR TITLE
Fix int64 printf

### DIFF
--- a/src/device.c
+++ b/src/device.c
@@ -830,7 +830,7 @@ static void print_idmaps(mpr_local_dev dev)
     mpr_id_map *map = &dev->idmaps.active[0];
     while (*map) {
         mpr_id_map m = *map;
-        printf("  %p: %llu (%d) -> %llu (%d)\n", m, m->LID, m->LID_refcount, m->GID, m->GID_refcount);
+        printf("  %p: %" PRIu64 " (%d) -> %" PRIu64 " (%d)\n", m, m->LID, m->LID_refcount, m->GID, m->GID_refcount);
         map = &(*map)->next;
     }
 }
@@ -844,7 +844,7 @@ mpr_id_map mpr_dev_add_idmap(mpr_local_dev dev, int group, mpr_id LID, mpr_id GI
     map = dev->idmaps.reserve;
     map->LID = LID;
     map->GID = GID ? GID : mpr_dev_generate_unique_id((mpr_dev)dev);
-    trace_dev(dev, "mpr_dev_add_idmap(%s) %llu -> %llu\n", dev->name, LID, map->GID);
+    trace_dev(dev, "mpr_dev_add_idmap(%s) %" PRIu64 " -> %" PRIu64 "\n", dev->name, LID, map->GID);
     map->LID_refcount = 1;
     map->GID_refcount = 0;
     dev->idmaps.reserve = map->next;
@@ -858,7 +858,7 @@ mpr_id_map mpr_dev_add_idmap(mpr_local_dev dev, int group, mpr_id LID, mpr_id GI
 
 static void mpr_dev_remove_idmap(mpr_local_dev dev, int group, mpr_id_map rem)
 {
-    trace_dev(dev, "mpr_dev_remove_idmap(%s) %llu -> %llu\n", dev->name, rem->LID, rem->GID);
+    trace_dev(dev, "mpr_dev_remove_idmap(%s) %" PRIu64 " -> %" PRIu64 "\n", dev->name, rem->LID, rem->GID);
     mpr_id_map *map = &dev->idmaps.active[group];
     while (*map) {
         if ((*map) == rem) {
@@ -876,7 +876,7 @@ static void mpr_dev_remove_idmap(mpr_local_dev dev, int group, mpr_id_map rem)
 
 int mpr_dev_LID_decref(mpr_local_dev dev, int group, mpr_id_map map)
 {
-    trace_dev(dev, "mpr_dev_LID_decref(%s) %llu -> %llu\n", dev->name, map->LID, map->GID);
+    trace_dev(dev, "mpr_dev_LID_decref(%s) %" PRIu64 " -> %" PRIu64 "\n", dev->name, map->LID, map->GID);
     --map->LID_refcount;
     trace_dev(dev, "  refcounts: {LID:%d, GID:%d}\n", map->LID_refcount, map->GID_refcount);
     if (map->LID_refcount <= 0) {
@@ -891,7 +891,7 @@ int mpr_dev_LID_decref(mpr_local_dev dev, int group, mpr_id_map map)
 
 int mpr_dev_GID_decref(mpr_local_dev dev, int group, mpr_id_map map)
 {
-    trace_dev(dev, "mpr_dev_GID_decref(%s) %llu -> %llu\n", dev->name, map->LID, map->GID);
+    trace_dev(dev, "mpr_dev_GID_decref(%s) %" PRIu64 " -> %" PRIu64 "\n", dev->name, map->LID, map->GID);
     --map->GID_refcount;
     trace_dev(dev, "  refcounts: {LID:%d, GID:%d}\n", map->LID_refcount, map->GID_refcount);
     if (map->GID_refcount <= 0) {

--- a/src/properties.c
+++ b/src/properties.c
@@ -607,7 +607,7 @@ void mpr_prop_print(int len, mpr_type type, const void *val)
             break;
         case MPR_INT64:
             for (i = 0; i < len; i++)
-                printf("%" PRINTF_LL "d, ", ((int64_t*)val)[i]);
+                printf("%" PRIi64 "d, ", ((int64_t*)val)[i]);
             break;
         case MPR_TIME:
             for (i = 0; i < len; i++)


### PR DESCRIPTION
This fixes compilation issues with printing `int64_t`/`uint64_t` values by using `%" PRIi64 "`/`%" PRIu64 "` instead of `%lld`/`%llu` because `int64` does not always translate to `long long int`:

From `/usr/include/bits/types.h`
```
#if __WORDSIZE == 64
typedef signed long int __int64_t;
typedef unsigned long int __uint64_t;
#else
__extension__ typedef signed long long int __int64_t;
__extension__ typedef unsigned long long int __uint64_t;
#endif 
```

With `gcc version 9.3.0 (Ubuntu 9.3.0-17ubuntu1~20.04)` without these fixes:
```
/bin/bash ../libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I.    -Wall -I../include  -I. -g -O0 -Wall -Werror -DDEBUG -g  -MT libmapper_la-device.lo -MD -MP -MF .deps/libmapper_la-device.Tpo -c -o libmapper_la-device.lo `test -f 'device.c' || echo './'`device.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -Wall -I../include -I. -g -O0 -Wall -Werror -DDEBUG -g -MT libmapper_la-device.lo -MD -MP -MF .deps/libmapper_la-device.Tpo -c device.c  -fPIC -DPIC -o .libs/libmapper_la-device.o
device.c: In function ‘print_idmaps’:
device.c:833:26: error: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 3 has type ‘mpr_id’ {aka ‘long unsigned int’} [-Werror=format=]
  833 |         printf("  %p: %llu (%d) -> %llu (%d)\n", m, m->LID, m->LID_refcount, m->GID, m->GID_refcount);
      |                       ~~~^                          ~~~~~~
      |                          |                           |
      |                          long long unsigned int      mpr_id {aka long unsigned int}
      |                       %lu
...
```

```
/bin/bash ../libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I.    -Wall -I../include  -I. -g -O0 -Wall -Werror -DDEBUG -g  -MT libmapper_la-properties.lo -MD -MP -MF .deps/libmapper_la-properties.Tpo -c -o libmapper_la-properties.lo `test -f 'properties.c' || echo './'`properties.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -Wall -I../include -I. -g -O0 -Wall -Werror -DDEBUG -g -MT libmapper_la-properties.lo -MD -MP -MF .deps/libmapper_la-properties.Tpo -c properties.c  -fPIC -DPIC -o .libs/libmapper_la-properties.o
properties.c: In function ‘mpr_prop_print’:
properties.c:610:24: error: format ‘%lld’ expects argument of type ‘long long int’, but argument 2 has type ‘int64_t’ {aka ‘long int’} [-Werror=format=]
  610 |                 printf("%" PRINTF_LL "d, ", ((int64_t*)val)[i]);
      |                        ^~~                  ~~~~~~~~~~~~~~~~~~
      |                                                            |
      |                                                            int64_t {aka long int}
properties.c:610:39: note: format string is defined here
  610 |                 printf("%" PRINTF_LL "d, ", ((int64_t*)val)[i]);
      |                         ~~~~~~~~~~~~~~^
      |                                       |
      |                                       long long int
...
```