### PR TITLE
Wheel with binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,6 @@ jobs:
         cp -v $PWD/inst/lib/libmapper.*.dylib bindings/python/libmapper/libmapper.dylib
         && pip3 wheel bindings/python -w ./wheelhouse
         && unzip -t wheelhouse/*.whl
-        && mv -v wheelhouse/*.whl $(echo wheelhouse/*.whl | sed -e s/-any./-$(python3 -c "import distutils.util; print(distutils.util.get_platform().replace('-','_').replace('.','_'))")./)
     - uses: actions/upload-artifact@v2
       with:
         path: ./wheelhouse/*.whl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,17 +14,25 @@ jobs:
     - name: install liblo
       run: curl -L -O https://downloads.sourceforge.net/project/liblo/liblo/0.31/liblo-0.31.tar.gz && tar -xzf liblo-0.31.tar.gz && cd liblo-0.31 && (./configure --host=$HOST --prefix=$PWD/inst --enable-static --disable-tests --disable-tools --disable-examples || (cat config.log; false)) && make install && find inst && cd ..
     - name: autogen
-      run: pwd && mkdir $PWD/inst && env NOCONFIGURE=1 ./autogen.sh && (./configure --enable-static --prefix=$PWD/inst PKG_CONFIG_PATH=$PWD/liblo-0.31/inst/lib/pkgconfig || (cat config.log; false))
+      run:
+        pwd
+        && mkdir $PWD/inst
+        && env NOCONFIGURE=1 am_opt=--copy ./autogen.sh
+        && (./configure --enable-static --prefix=$PWD/inst PKG_CONFIG_PATH=$PWD/liblo-0.31/inst/lib/pkgconfig || (cat config.log; false))
     - name: make
       run: make && (make check || (for i in src/*.log; do echo === $i ===; cat $i; done; false)) && make install && find inst
     - name: make tests
       run: cd test && make tests
+    - name: make dist
+      run: make dist
     - name: python wheels
       run:
-        cd bindings/python && pip3 wheel . -w ./wheelhouse/
+        pwd && make distclean && bindings/python/build_wheels.py
     - uses: actions/upload-artifact@v2
       with:
-        path: ./bindings/python/wheelhouse/*.whl
+        path: |
+          libmapper*.tar.gz
+          ./wheelhouse/*.whl
 
   MacOS:
     runs-on: macOS-latest
@@ -35,7 +43,7 @@ jobs:
     - name: install dependencies
       run: brew install autoconf-archive automake
     - name: install liblo
-      run: curl -L -O https://downloads.sourceforge.net/project/liblo/liblo/0.31/liblo-0.31.tar.gz && tar -xzf liblo-0.31.tar.gz && cd liblo-0.31 && (./configure --host=$HOST --prefix=$PWD/inst --enable-static --disable-tests --disable-tools --disable-examples || (cat config.log; false)) && make install && find inst && cd ..
+      run: curl -L -O https://downloads.sourceforge.net/project/liblo/liblo/0.31/liblo-0.31.tar.gz && tar -xzf liblo-0.31.tar.gz && cd liblo-0.31 && (./configure --host=$HOST --prefix=$PWD/inst --enable-static --disable-shared --disable-tests --disable-tools --disable-examples CFLAGS=-fPIC || (cat config.log; false)) && make install && find inst && cd ..
     - name: autogen
       run: pwd && mkdir $PWD/inst && (./autogen.sh --enable-static --prefix=$PWD/inst PKG_CONFIG_PATH=$PWD/liblo-0.31/inst/lib/pkgconfig || (cat config.log; false))
     - name: make
@@ -44,10 +52,12 @@ jobs:
       run: cd test && make tests
     - name: python wheels
       run:
-        cd bindings/python && pip3 wheel . -w ./wheelhouse/
+        cp -v $PWD/inst/lib/libmapper.*.dylib bindings/python/libmapper/libmapper.dylib
+        && pip3 wheel bindings/python -w ./wheelhouse
+        && unzip -t wheelhouse/*.whl
     - uses: actions/upload-artifact@v2
       with:
-        path: ./bindings/python/wheelhouse/*.whl
+        path: ./wheelhouse/*.whl
   
   MinGW:
     runs-on: ubuntu-latest
@@ -58,11 +68,19 @@ jobs:
     - name: install dependencies
       run: sudo apt-get install g++-mingw-w64 autoconf-archive curl
     - name: install liblo
-      run: curl -L -O https://downloads.sourceforge.net/project/liblo/liblo/0.31/liblo-0.31.tar.gz && tar -xzf liblo-0.31.tar.gz && cd liblo-0.31 && (./configure --host="x86_64-w64-mingw32" --prefix=$PWD/inst --enable-static --disable-tests --disable-tools --disable-examples || (cat config.log; false)) && make install && find inst && cd ..
+      run: curl -L -O https://downloads.sourceforge.net/project/liblo/liblo/0.31/liblo-0.31.tar.gz && tar -xzf liblo-0.31.tar.gz && cd liblo-0.31 && (./configure --host="x86_64-w64-mingw32" --prefix=$PWD/inst --disable-tests --disable-tools --disable-examples || (cat config.log; false)) && make install && find inst && cd ..
     - name: install zlib
       run: unset CC && unset CXX && curl -L -O http://www.zlib.net/zlib-1.2.11.tar.gz && tar -xzf zlib-1.2.11.tar.gz && cp -v zlib-1.2.11/crc32.c src/ && echo libmapper_la_SOURCES += crc32.c >>src/Makefile.am && echo libmapper_la_CFLAGS += -I\$\(top_srcdir\)/zlib-1.2.11 >>src/Makefile.am && sed -e 's,\(AC_CHECK_LIB(\[z\]\),dnl \1,' -i configure.ac && sed -e 's,\(\./\$\$i\),wine \1.exe,' -i test/Makefile.am
     - name: autogen
       run: pwd && mkdir $PWD/inst && (./autogen.sh --host="x86_64-w64-mingw32" --enable-static --disable-python --disable-jni --prefix=$PWD/inst PKG_CONFIG_PATH=$PWD/liblo-0.31/inst/lib/pkgconfig || (cat config.log; false))
     - name: make
       run: make && make install && find inst
-      
+    - name: python wheels
+      run:
+        cp -v $PWD/inst/bin/libmapper-*.dll bindings/python/libmapper/libmapper.dll
+        && pip3 wheel bindings/python -w ./wheelhouse
+        && unzip -t wheelhouse/*.whl
+        && mv wheelhouse/*.whl wheelhouse/$(basename wheelhouse/*.whl .whl).windows.whl
+    - uses: actions/upload-artifact@v2
+      with:
+        path: ./wheelhouse/*.whl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           libmapper*.tar.gz
           ./wheelhouse/*.whl
 
-  MacOS:
+  MacOS-Latest:
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v2
@@ -58,7 +58,32 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         path: ./wheelhouse/*.whl
-  
+
+  MacOS-10:
+    runs-on: macOS-10.15
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: brew install autoconf-archive automake
+    - name: install liblo
+      run: curl -L -O https://downloads.sourceforge.net/project/liblo/liblo/0.31/liblo-0.31.tar.gz && tar -xzf liblo-0.31.tar.gz && cd liblo-0.31 && (./configure --host=$HOST --prefix=$PWD/inst --enable-static --disable-shared --disable-tests --disable-tools --disable-examples CFLAGS=-fPIC || (cat config.log; false)) && make install && find inst && cd ..
+    - name: autogen
+      run: pwd && mkdir $PWD/inst && (./autogen.sh --enable-static --prefix=$PWD/inst PKG_CONFIG_PATH=$PWD/liblo-0.31/inst/lib/pkgconfig || (cat config.log; false))
+    - name: make
+      run: make && (make check || (for i in src/*.log; do echo === $i ===; cat $i; done; false)) && make install && find inst
+    - name: make tests
+      run: cd test && make tests
+    - name: python wheels
+      run:
+        cp -v $PWD/inst/lib/libmapper.*.dylib bindings/python/libmapper/libmapper.dylib
+        && pip3 wheel bindings/python -w ./wheelhouse
+        && unzip -t wheelhouse/*.whl
+    - uses: actions/upload-artifact@v2
+      with:
+        path: ./wheelhouse/*.whl
+
   MinGW:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: C/C++ CI
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [push, pull_request]
 
 jobs:
   Linux:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
         cp -v $PWD/inst/lib/libmapper.*.dylib bindings/python/libmapper/libmapper.dylib
         && pip3 wheel bindings/python -w ./wheelhouse
         && unzip -t wheelhouse/*.whl
+        && mv -v wheelhouse/*.whl $(echo wheelhouse/*.whl | sed -e s/-any./-$(python3 -c "import distutils.util; print(distutils.util.get_platform().replace('-','_').replace('.','_'))")./)
     - uses: actions/upload-artifact@v2
       with:
         path: ./wheelhouse/*.whl
@@ -80,7 +81,7 @@ jobs:
         cp -v $PWD/inst/bin/libmapper-*.dll bindings/python/libmapper/libmapper.dll
         && pip3 wheel bindings/python -w ./wheelhouse
         && unzip -t wheelhouse/*.whl
-        && mv wheelhouse/*.whl wheelhouse/$(basename wheelhouse/*.whl .whl).windows.whl
+        && mv -v wheelhouse/*.whl $(echo wheelhouse/*.whl | sed -e s/-any./-win32./)
     - uses: actions/upload-artifact@v2
       with:
         path: ./wheelhouse/*.whl

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -14,7 +14,7 @@ uninstall-hook:
 	cat @top_builddir@/bindings/python/installed_files.log \
 	  | awk '{print "$(DESTDIR)"$$1}' | xargs rm -vf
 
-EXTRA_DIST = libmapper.py test.py testcallbacks.py testconvergent.py testinstance.py \
+EXTRA_DIST = libmapper/__init__.py test.py testcallbacks.py testconvergent.py testinstance.py \
              testmapfromstr.py testreverse.py testvector.py tkgui.py
 
 test_all_ordered = test testcallbacks testconvergent testinstance testmapfromstr testreverse testvector

--- a/bindings/python/build_wheels.py
+++ b/bindings/python/build_wheels.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+# This script executes the manylinux Docker images in order to build each supported
+# platform wheel.
+
+import os
+import subprocess
+import multiprocessing
+from pprint import pprint
+
+def platforms():
+    ARCHES = ['x86_64', 'i686'] # WIP: 'aarch64', 'armv7l', 'ppc64', 'ppc64le', 's390x'
+    BASES = ['manylinux2010',  'manylinux2014', 'manylinux_2_24']
+    for base in BASES:
+        for arch in ARCHES:
+            if base == 'manylinux2010' and arch not in ['x86_64', 'i686']:
+                continue
+            yield f'{base}_{arch}'
+
+def build_wheel(platform):
+    cmd = ['docker', 'run', '--rm', '-e', f'PLAT={platform}',
+           '-v', f'{os.getcwd()}:/package',
+           f'quay.io/pypa/{platform}',
+           '/package/bindings/python/manylinux.sh']
+    print(' '.join(cmd))
+    subprocess.check_call(cmd, stdout=open('/dev/null', 'wb'))
+    return platform
+
+with multiprocessing.Pool(8) as pool:
+    result = list(pool.map(build_wheel, platforms()))
+print('Wheels built for:')
+pprint(result)

--- a/bindings/python/libmapper/__init__.py
+++ b/bindings/python/libmapper/__init__.py
@@ -1,0 +1,1 @@
+from .mapper import *

--- a/bindings/python/libmapper/mapper.py.in
+++ b/bindings/python/libmapper/mapper.py.in
@@ -1,7 +1,18 @@
+__all__ = [
+
+    '__version__', 'Device', 'Location', 'Direction', 'Operator', 'Property',
+    'Protocol', 'Status', 'Stealing', 'Type', 'Time', 'Object', 'List', 'InstanceId',
+    'Signal', 'SignalInstance', 'Map', 'Graph'
+
+]
+
 from ctypes import *
 from enum import IntFlag, Enum
 import weakref, sys
 import platform
+import os
+
+__version__ = '@PACKAGE_VERSION@'
 
 # need different library extensions for Linux, Windows, MacOS
 if platform.uname()[0] == "Windows":
@@ -10,7 +21,10 @@ elif platform.uname()[0] == "Linux":
     name = "libmapper.so"
 else:
     name = "libmapper.dylib"
-mpr = cdll.LoadLibrary(name)
+try:
+    mpr = cdll.LoadLibrary(os.path.join(os.path.dirname(__file__), name))
+except IOError:
+    mpr = cdll.LoadLibrary(name)
 
 # configuration of Py_IncRef and Py_DecRef
 _c_inc_ref = pythonapi.Py_IncRef

--- a/bindings/python/manylinux.sh
+++ b/bindings/python/manylinux.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+# This script is intended to be run under a "manylinux" Docker distribution for building
+# Python wheels.
+
+if [ -z "$PLAT" ]; then
+    echo No manylinux platform was defined in \$PLAT
+    exit 1
+fi
+
+set -e
+set -x
+
+ROOT=$(readlink -f $(dirname $0)/../..)
+cd $ROOT
+
+TMP=$(mktemp -d)
+INST=$TMP/inst
+
+(
+    echo === Building liblo
+    TAR=$PWD/liblo-0.31.tar.gz
+    if ! (echo '14378c1e74c58e777fbb4fcf33ac5315  liblo-0.31.tar.gz'  | md5sum -c -); then
+        curl -L -O https://downloads.sourceforge.net/project/liblo/liblo/0.31/liblo-0.31.tar.gz
+        echo '14378c1e74c58e777fbb4fcf33ac5315  liblo-0.31.tar.gz' | md5sum -c -
+    fi
+    cd $TMP
+    tar -xzf $TAR
+    cd liblo-0.31
+    ./configure --host=$HOST --prefix=$INST --disable-tests --disable-tools --disable-examples \
+        || (cat config.log; echo "Error."; false)
+    make clean
+    make install -j4
+    find $INST
+) || exit 1
+
+echo === Building libmapper
+mkdir -p $TMP/libmapper
+cd $TMP/libmapper
+PKG_CONFIG_PATH=$INST/lib/pkgconfig $ROOT/configure \
+  --prefix=$INST --disable-tests --disable-audio --disable-jni \
+  --libdir=$TMP/libmapper/bindings/python/libmapper || bash -i
+make clean
+make install -j4
+
+python3.6 -m pip wheel -w $TMP/wheelhouse $TMP/libmapper/bindings/python
+unzip -t $TMP/wheelhouse/*.whl
+for WHL in $TMP/wheelhouse/*.whl; do
+    auditwheel repair $WHL --plat "$PLAT" -w $ROOT/wheelhouse || bash -i
+done

--- a/bindings/python/setup.py.in
+++ b/bindings/python/setup.py.in
@@ -14,4 +14,6 @@ setup (name = 'libmapper',
        description = """A library for mapping controllers and synthesizers.""",
        license = "GNU LGPL version 2.1 or later",
        py_modules = ["libmapper"],
-       )
+       packages = ["libmapper"],
+       package_data = {"libmapper": ["libmapper.@SO_EXT@"]},
+)

--- a/bindings/python/setup.py.in
+++ b/bindings/python/setup.py.in
@@ -5,15 +5,23 @@ setup.py file for python mapper
 """
 
 from distutils.core import setup
+import re
 
-setup (name = 'libmapper',
-       version = '@PACKAGE_VERSION@',
-       author      = "libmapper.org",
+def ver():
+    version = '@PACKAGE_VERSION@'
+    match = re.compile(r'(\d+)\.(\d+)(\w*)(\d*)\.(\d+)\+?.*').match(version)
+    if match:
+        return '{0}.{1}{2}{3}.dev{4}'.format(*[g or "" for g in match.groups()])
+    else:
+        return version
+
+setup (name         = 'libmapper',
+       version      = ver(),
+       author       = "libmapper.org",
        author_email = "dot_mapper@googlegroups.com",
-       url = "http://libmapper.org",
-       description = """A library for mapping controllers and synthesizers.""",
-       license = "GNU LGPL version 2.1 or later",
-       py_modules = ["libmapper"],
-       packages = ["libmapper"],
+       url          = "http://libmapper.org",
+       description  = """A library for mapping controllers and synthesizers.""",
+       license      = "GNU LGPL version 2.1 or later",
+       packages     = ["libmapper"],
        package_data = {"libmapper": ["libmapper.@SO_EXT@"]},
 )

--- a/bindings/python/setup.py.in
+++ b/bindings/python/setup.py.in
@@ -6,6 +6,7 @@ setup.py file for python mapper
 
 from distutils.core import setup
 import re
+import platform
 
 def ver():
     version = '@PACKAGE_VERSION@'
@@ -14,6 +15,24 @@ def ver():
         return '{0}.{1}{2}{3}.dev{4}'.format(*[g or "" for g in match.groups()])
     else:
         return version
+
+try:
+    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+
+    class bdist_wheel(_bdist_wheel):
+
+        def finalize_options(self):
+            _bdist_wheel.finalize_options(self)
+            # Mark us as not a pure python package
+            self.root_is_pure = False
+
+        def get_tag(self):
+            python, abi, plat = _bdist_wheel.get_tag(self)
+            # We don't contain any python source
+            python, abi = 'py3', 'none'
+            return python, abi, plat
+except ImportError:
+    bdist_wheel = None
 
 setup (name         = 'libmapper',
        version      = ver(),
@@ -24,4 +43,7 @@ setup (name         = 'libmapper',
        license      = "GNU LGPL version 2.1 or later",
        packages     = ["libmapper"],
        package_data = {"libmapper": ["libmapper.@SO_EXT@"]},
+       cmdclass     = {
+        'bdist_wheel': bdist_wheel,
+       } if platform.uname()[0] != 'Linux' else {},
 )

--- a/build_darwin_binaries.sh
+++ b/build_darwin_binaries.sh
@@ -150,8 +150,9 @@ function make_bundles()
     mkdir -v $APP/Contents
     mkdir -v $APP/Contents/MacOS
     mkdir -v $APP/Contents/Resources
-    cp -v libmapper-$LIBMAPPER_VERSION/src/.libs/libmapper.*.dylib $APP/Contents/MacOS/libmapper.dylib
-    cp -v libmapper-$LIBMAPPER_VERSION/bindings/python/libmapper.py $APP/Contents/MacOS/
+    cp -v libmapper-$LIBMAPPER_VERSION/src/.libs/libmapper.*.dylib $APP/Contents/MacOS/libmapper/libmapper.dylib
+    cp -v libmapper-$LIBMAPPER_VERSION/bindings/python/mapper.py $APP/Contents/MacOS/
+    cp -v libmapper-$LIBMAPPER_VERSION/bindings/python/__init__.py $APP/Contents/MacOS/libmapper/
     cp -v libmapper-$LIBMAPPER_VERSION/bindings/python/tkgui.py $APP/Contents/MacOS/
     echo 'APPL????' >$APP/Contents/PkgInfo
     info_plist $APP/Contents/Info.plist libmapper_Slider_Example tkgui.py

--- a/configure.ac
+++ b/configure.ac
@@ -193,6 +193,7 @@ if test x$enable_python = xyes; then
      3*) PY3=" -py3"; AC_SUBST(PY3)
      esac
      python_explain="($(basename $PYTHON)$PY3)"
+     AC_CONFIG_LINKS([bindings/python/libmapper/__init__.py:bindings/python/libmapper/__init__.py])
    else
      enable_python=no
      python_explain="(python not found)"
@@ -291,8 +292,8 @@ if test x$enable_audio = xyes; then
     RTAUDIO_CFLAGS="-D__MACOSX_CORE__ -D__LITTLE_ENDIAN__"
     RTAUDIO_LIBS="-framework CoreAudio -framework CoreFoundation"
     audio_explain="(CoreAudio)"
-    echo yes
-  else
+  echo yes
+    else
     echo no
   fi
 
@@ -304,6 +305,17 @@ fi
 
 AC_SUBST(RTAUDIO_CFLAGS)
 AC_SUBST(RTAUDIO_LIBS)
+
+# Library filename extension
+if test x$is_windows = xyes; then
+  SO_EXT=dll
+else
+  case "$(uname -s)" in
+    *arwin*) SO_EXT=dylib;;
+    *) SO_EXT=so;;
+  esac
+fi
+AC_SUBST(SO_EXT)
 
 # Doxygen
 if test x$enable_docs = xyes; then
@@ -379,6 +391,7 @@ AC_CONFIG_FILES([
     bindings/csharp/Makefile
     bindings/python/Makefile
     bindings/python/setup.py
+    bindings/python/libmapper/mapper.py
     examples/Makefile
     examples/pwm_synth/Makefile
     extra/Makefile

--- a/doc/tutorials/tutorial_python.md
+++ b/doc/tutorials/tutorial_python.md
@@ -2,8 +2,8 @@
 
 Since _libmapper_ uses GNU autoconf, getting started with the library is the
 same as any other library on Linux; use `./configure` and then `make` to compile
-it.  There is a file named `libmapper.py` in the directory `/bindings/python/`
-that you will need to copy into your project.
+it.  There is a directory named `libmapper` in `/bindings/python/` that you will
+need to copy into your project.
 
 Once you have libmapper installed, it can be imported into your program:
 


### PR DESCRIPTION
Attempts for Linux, Mac, Windows.  Needs more testing before merge.

Moves libmapper.py into a package directory "libmapper", so that binaries can be put beside it.
Still only "import libmapper" is needed for use however as all symbols are imported to top level.

Binaries can be tested by downloading the artifact.zip from the Github Action, and installing one of the ".whl" files it contains via "pip" into a clean virtual env.

Update: I was unable to get the Windows build to link statically with liblo, and the utility "delvewheel" that is supposed to include liblo into the wheel does not work in the Linux environment, so probably the Windows wheel does not work.