### PR TITLE
Windows: Remove pause after build completed

### DIFF
--- a/windows_build.ps1
+++ b/windows_build.ps1
@@ -37,4 +37,3 @@ cd bindings\python\
 
 Write-Host "Done! dll's for liblo and zlib are located in the build/ folder"
 Write-Host "build/Debug/ contains the libmapper dll"
-Pause


### PR DESCRIPTION
Shouldn't wait for user confirmation after build, will disrupt 3rd party repos building libmapper in their own build scripts (aka mapper-max-pd)