### PR TITLE
Windows build script improvements for dlls and python wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
       shell: pwsh
       run: .\windows_build.ps1
     - name: Build python wheel
-      run: .\windows_build_wheel.ps1
+      run: .\bindings\python\windows_build_wheel.ps1
     - uses: actions/upload-artifact@v3
       with:
         path: ./bindings/python/dist/*.whl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,10 +156,8 @@ jobs:
     - name: Run windows PowerShell build script
       shell: pwsh
       run: .\windows_build.ps1
-    - name: Copy dlls to python dir
-      run: cp -v $PWD/build/Debug/libmapper.dll bindings/python/libmapper/libmapper.dll && cp -v $PWD/build/liblo/liblo-master/cmake/build/Debug/liblo.dll bindings/python/libmapper/liblo.dll && cp -v $PWD/build/zlib/msvc2017_64/lib/zlib/zlib.dll bindings/python/libmapper/zlib.dll
     - name: Build python wheel
-      run: pip install wheel && cd bindings/python && python setup.py bdist_wheel
+      run: .\windows_build_wheel.ps1
     - uses: actions/upload-artifact@v3
       with:
         path: ./bindings/python/dist/*.whl

--- a/bindings/python/get_version.ps1
+++ b/bindings/python/get_version.ps1
@@ -1,3 +1,0 @@
-$versionString = git describe --tags
-$versionString = $versionString -replace '([0-9.]+)-([0-9]+)-([a-z0-9]+)', '$1.$2+$3'
-(gc ./libmapper/mapper.py) -replace '__version__ = ''@PACKAGE_VERSION@''', "__version__ = '$versionString'" | Out-File -encoding ASCII ./libmapper/mapper.py

--- a/bindings/python/windows_build_wheel.ps1
+++ b/bindings/python/windows_build_wheel.ps1
@@ -1,0 +1,17 @@
+cd $PSScriptRoot
+
+# Replace version env variable with actual version
+$versionString = git describe --tags
+$versionString = $versionString -replace '([0-9.]+)-([0-9]+)-([a-z0-9]+)', '$1.$2+$3'
+(gc ./libmapper/mapper.py) -replace '__version__ = ''@PACKAGE_VERSION@''', "__version__ = '$versionString'" | Out-File -encoding ASCII ./libmapper/mapper.py
+
+# Copy dlls to python bindings folder
+cp -v ../../dist/libmapper.dll ./libmapper/libmapper.dll
+cp -v ../../dist/liblo.dll ./libmapper/liblo.dll
+cp -v ../../dist/zlib.dll ./libmapper/zlib.dll
+
+# Build python wheel
+pip install wheel
+python setup.py bdist_wheel
+
+Write-Host "Done! Python wheel located in the bindings/python/dist/ folder"

--- a/bindings/python/windows_build_wheel.ps1
+++ b/bindings/python/windows_build_wheel.ps1
@@ -1,5 +1,9 @@
 cd $PSScriptRoot
 
+# Rename .py.in files to .py for Windows
+cp ./setup.py.in ./setup.py
+cp ./libmapper/mapper.py.in ./libmapper/mapper.py
+
 # Replace version env variable with actual version
 $versionString = git describe --tags
 $versionString = $versionString -replace '([0-9.]+)-([0-9]+)-([a-z0-9]+)', '$1.$2+$3'

--- a/doc/how_to_compile_and_run.md
+++ b/doc/how_to_compile_and_run.md
@@ -189,15 +189,15 @@ Cmake is required to generate visual studio solutions, and can be installed [her
 
 [cmake]: https://cmake.org/download/
 
-You'll also need Visual Studio 2017 or 2019, which you can grab [here][visual_studio]. Be sure to install the C++ developer tools when installing if you don't already have them.
+You'll also need Visual Studio 2017 or 2019, which you can grab [here][visual_studio]. Be sure to install the MSVC C++ SDK when installing if you don't already have it.
 
 [visual_studio]: https://visualstudio.microsoft.com/vs/
 
-Once cmake is installed and added to the environment path, libmapper and its dependencies (zlib and liblo) can be built the easy way by double clicking 
+Once cmake is installed and added to the environment path, libmapper and its dependencies (zlib and liblo) can be built the easy way by running
 
-    build_windows.bat
+    build_windows.ps1
 
-and checking the build/Debug folder to retrieve your libmapper dll. The liblo and zlib dlls can also be found in their respective subfolders in the build/ directory, and should be copied along with the libmapper dll to any directory using libmapper. Tests can be run in build/test/Debug to verify the correct functions, but be sure to copy the dlls (zlib, liblo, libmapper) to the same folder as the executables or add their paths to your PATH environment variable.
+using powershell or "Run in powershell" form the right-click menu on the file. The libmapper, liblo and zlib dlls can be found in the dist/ directory. Tests can be run in dist/tests/ to verify the correct functions, but be sure to copy the dlls (zlib, liblo, libmapper) to the same folder as the executables or add their paths to your PATH environment variable.
 
 If you want to manually build from source, follow the instructions below. If you ran the batch file above, you should be done!
 

--- a/doc/how_to_compile_and_run.md
+++ b/doc/how_to_compile_and_run.md
@@ -193,13 +193,11 @@ You'll also need Visual Studio 2017 or 2019, which you can grab [here][visual_st
 
 [visual_studio]: https://visualstudio.microsoft.com/vs/
 
-Once cmake is installed and added to the environment path, libmapper and its dependencies (zlib and liblo) can be built the easy way by running
+Once cmake is installed and added to the environment path, libmapper and its dependencies (zlib and liblo) can be built the easy way by running `windows_build.ps1` using powershell or "Run in powershell" form the right-click menu on the file. The libmapper, liblo and zlib dlls can be found in the dist/ directory. Tests can be run in dist/tests/ to verify the correct functions, but be sure to copy the dlls (zlib, liblo, libmapper) to the same folder as the executables or add their paths to your PATH environment variable.
 
-    build_windows.ps1
+To build the python wheel, run the `windows_build_wheel.ps1` script from /bindings/python.
 
-using powershell or "Run in powershell" form the right-click menu on the file. The libmapper, liblo and zlib dlls can be found in the dist/ directory. Tests can be run in dist/tests/ to verify the correct functions, but be sure to copy the dlls (zlib, liblo, libmapper) to the same folder as the executables or add their paths to your PATH environment variable.
-
-If you want to manually build from source, follow the instructions below. If you ran the batch file above, you should be done!
+If you want to manually build from source, follow the instructions below. If you ran the powershell file above, you should be done!
 
 ### Manual compilation
 

--- a/windows_build.ps1
+++ b/windows_build.ps1
@@ -32,8 +32,19 @@ cmake --build . --target all_build
 cd $scriptDir
 cp ./bindings/python/setup.py.in ./bindings/python/setup.py
 cp ./bindings/python/libmapper/mapper.py.in ./bindings/python/libmapper/mapper.py
-cd bindings\python\
+cd bindings/python/
 ./get_version.ps1
 
-Write-Host "Done! dll's for liblo and zlib are located in the build/ folder"
-Write-Host "build/Debug/ contains the libmapper dll"
+# Create dist directory for dlls and wheel
+cd $scriptDir
+if (!(Test-Path "$($scriptDir)\dist\")) {
+  mkdir dist
+}
+# Copy dlls to /dist
+cp -v ./build/Debug/libmapper.dll ./dist/libmapper.dll
+cp -v ./build/liblo/liblo-master/cmake/build/Debug/liblo.dll ./dist/liblo.dll
+cp -v ./build/zlib/msvc2017_64/lib/zlib/zlib.dll ./dist/zlib.dll
+# Copy test files
+cp -v ./build/test/Debug/* ./dist/tests
+
+Write-Host "Done! dll's for liblo and zlib are located in the dist/ folder"

--- a/windows_build.ps1
+++ b/windows_build.ps1
@@ -27,14 +27,6 @@ cd "$($scriptDir)\build"
 cmake ..
 cmake --build . --target all_build
 
-# Rename .py.in files to .py for Windows
-# Reset active directory
-cd $scriptDir
-cp ./bindings/python/setup.py.in ./bindings/python/setup.py
-cp ./bindings/python/libmapper/mapper.py.in ./bindings/python/libmapper/mapper.py
-cd bindings/python/
-./get_version.ps1
-
 # Create dist directory for dlls and wheel
 cd $scriptDir
 if (!(Test-Path "$($scriptDir)\dist\")) {


### PR DESCRIPTION
- refactor windows build script to copy dlls and built tests to /dist folder
- refactor get_version.ps1 -> build_windows_wheel.ps1 to build python wheel
- change ci.yml to only call the 2 ps1 scripts for windows
- update documentation to match new scripts

Tested the installed wheel with webmapper and will be clear to merge https://github.com/libmapper/webmapper/pull/26 once this is brought in.