### PR TITLE
adds debug support for windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,9 @@ if (WIN32)
   mark_as_advanced(Liblo_LIB)
   mark_as_advanced(Zlib_LIB)
 
+  set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DDEBUG")
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG")
+
   add_definitions(
     -DWIN_VERSION
     -D_USE_MATH_DEFINES

--- a/src/mapper_internal.h
+++ b/src/mapper_internal.h
@@ -41,7 +41,7 @@ if (!(a)) { trace_net(__VA_ARGS__); return ret; }
 /**** Debug macros ****/
 
 /*! Debug tracer */
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(WIN32)
 #ifdef DEBUG
 #include <stdio.h>
 #include <assert.h>


### PR DESCRIPTION
- Adds DEBUG preprocessor definition when built in Debug mode on windows so that libmapper traces print
- Small fix for debug print definitions so that windows is welcome too