### PR TITLE
C# Wrapper: Fix null dereferences

### DIFF
--- a/bindings/csharp/Mapper.cs
+++ b/bindings/csharp/Mapper.cs
@@ -50,7 +50,7 @@ namespace Mapper
         // internal long _time;
 
         [StructLayout(LayoutKind.Explicit)]
-        public struct MprTimeStruct
+        internal struct timeStruct
         {
             [FieldOffset(0)]
             internal long ntp;
@@ -59,7 +59,7 @@ namespace Mapper
             [FieldOffset(4)]
             internal UInt32 frac;
         }
-        internal MprTimeStruct data;
+        internal timeStruct data;
 
         public Time(long ntp)
             { data.ntp = ntp; }
@@ -1030,14 +1030,14 @@ namespace Mapper
         }
 
         [DllImport("mapper", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.StdCall)]
-        unsafe private static extern void* mpr_sig_get_value(IntPtr sig, UInt64 id, ref Time.MprTimeStruct time);
+        unsafe private static extern void* mpr_sig_get_value(IntPtr sig, UInt64 id, ref long time);
         unsafe public (dynamic, Time) GetValue(UInt64 instanceId = 0)
         {
             int len = mpr_obj_get_prop_as_int32(this._obj, (int)Property.Length, null);
             int type = mpr_obj_get_prop_as_int32(this._obj, (int)Property.Type, null);
-            var time = new Time.MprTimeStruct();
+            long time = 0;
             void *val = mpr_sig_get_value(this._obj, instanceId, ref time);
-            return (BuildValue(len, type, val, 0), new Time(time.ntp));
+            return (BuildValue(len, type, val, 0), new Time(time));
         }
         // unsafe public dynamic GetValue(UInt64 instanceId = 0)
         // {

--- a/bindings/csharp/Mapper.cs
+++ b/bindings/csharp/Mapper.cs
@@ -1035,7 +1035,11 @@ namespace Mapper
             int type = mpr_obj_get_prop_as_int32(this._obj, (int)Property.Type, null);
             long time = 0;
             void *val = mpr_sig_get_value(this._obj, instanceId, ref time);
-            return (BuildValue(len, type, val, 0), new Time(*(long*)time));
+            if (time == 0) { // signal not written to yet, so time is a null pointer
+                return (BuildValue(len, type, val, 0), new Time());
+            } else {
+                return (BuildValue(len, type, val, 0), new Time(*(long*)time));
+            }
         }
         // unsafe public dynamic GetValue(UInt64 instanceId = 0)
         // {

--- a/bindings/csharp/Mapper.cs
+++ b/bindings/csharp/Mapper.cs
@@ -251,6 +251,8 @@ namespace Mapper
         {
             if (0 == len)
                 return null;
+            if (value == null)
+                return null;
             switch (type)
             {
                 case (int)Type.Int32:

--- a/bindings/csharp/Mapper.cs
+++ b/bindings/csharp/Mapper.cs
@@ -50,7 +50,7 @@ namespace Mapper
         // internal long _time;
 
         [StructLayout(LayoutKind.Explicit)]
-        internal struct timeStruct
+        public struct MprTimeStruct
         {
             [FieldOffset(0)]
             internal long ntp;
@@ -59,7 +59,7 @@ namespace Mapper
             [FieldOffset(4)]
             internal UInt32 frac;
         }
-        internal timeStruct data;
+        internal MprTimeStruct data;
 
         public Time(long ntp)
             { data.ntp = ntp; }
@@ -1030,18 +1030,14 @@ namespace Mapper
         }
 
         [DllImport("mapper", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.StdCall)]
-        unsafe private static extern void* mpr_sig_get_value(IntPtr sig, UInt64 id, ref long time);
+        unsafe private static extern void* mpr_sig_get_value(IntPtr sig, UInt64 id, ref Time.MprTimeStruct time);
         unsafe public (dynamic, Time) GetValue(UInt64 instanceId = 0)
         {
             int len = mpr_obj_get_prop_as_int32(this._obj, (int)Property.Length, null);
             int type = mpr_obj_get_prop_as_int32(this._obj, (int)Property.Type, null);
-            long time = 0;
+            var time = new Time.MprTimeStruct();
             void *val = mpr_sig_get_value(this._obj, instanceId, ref time);
-            if (time == 0) { // signal not written to yet, so time is a null pointer
-                return (BuildValue(len, type, val, 0), new Time());
-            } else {
-                return (BuildValue(len, type, val, 0), new Time(*(long*)time));
-            }
+            return (BuildValue(len, type, val, 0), new Time(time.ntp));
         }
         // unsafe public dynamic GetValue(UInt64 instanceId = 0)
         // {


### PR DESCRIPTION
Currently the C# wrapper attempts to dereference two null pointers if reading a signal that hasn't been written to yet.

Both the time and the value will be null pointers, and these commits change the behaviour to return a tuple of `(null, <Default Timestamp>)`.