### PR TITLE
CSharp: Add instanceId parameter to SetValue

### DIFF
--- a/bindings/csharp/Mapper.cs
+++ b/bindings/csharp/Mapper.cs
@@ -1020,10 +1020,10 @@ namespace Mapper
             }
         }
 
-        public Signal SetValue<T>(T value)
+        public Signal SetValue<T>(T value, UInt64 instanceId = 0)
         {
             dynamic temp = value;
-            _SetValue(temp, 0);
+            _SetValue(temp, instanceId);
             return this;
         }
 


### PR DESCRIPTION
Seems like there's no way to specify the instance id when setting a value in the C# Wrapper, this adds an optional parameter to do that.