### PR TITLE
Add links to binding packages

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -19,10 +19,23 @@
       src="https://img.shields.io/github/tag/libmapper/libmapper.svg?style=flat-square"
     />
   </a>
-  <a href="https://github.com/libmapper/libmapper/releases">
+  
+  <a href="https://pypi.org/project/libmapper/">
     <img
-      alt="downloads:?"
-      src="https://img.shields.io/github/downloads/libmapper/libmapper/total.svg?style=flat-square"
+      alt="pipi:?"
+      src="https://img.shields.io/pypi/v/libmapper?color=%23f7e11b"
+    />
+  </a>
+  <a href="https://www.nuget.org/packages/Libmapper.NET">
+    <img
+      alt="nuget:?"
+      src="https://img.shields.io/nuget/v/Mapper.NET"
+    />
+  </a>
+  <a href="https://crates.io/crates/libmapper-rs">
+    <img
+      alt="crate:?"
+      src="https://img.shields.io/crates/v/libmapper-rs?color=%23fede9e"
     />
   </a>
   <a href="https://github.com/libmapper/libmapper/actions/workflows/ci.yml">

--- a/bindings/csharp/Libmapper.NET/Signal.cs
+++ b/bindings/csharp/Libmapper.NET/Signal.cs
@@ -292,6 +292,14 @@ public class Signal : MapperObject
             throw new ArgumentException("Unsupported type passed to SetValue");
         return this;
     }
+    
+    [DllImport("mapper", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.StdCall)]
+    private static extern unsafe void* mpr_sig_release_inst(IntPtr sig, ulong id);
+
+    public unsafe void Release(ulong id = 0)
+    {
+        mpr_sig_release_inst(this.NativePtr, id);
+    }
 
     [DllImport("mapper", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.StdCall)]
     private static extern unsafe void* mpr_sig_get_value(IntPtr sig, ulong id, ref long time);

--- a/bindings/csharp/Libmapper.NET/Signal.cs
+++ b/bindings/csharp/Libmapper.NET/Signal.cs
@@ -296,6 +296,10 @@ public class Signal : MapperObject
     [DllImport("mapper", CharSet = CharSet.Ansi, CallingConvention = CallingConvention.StdCall)]
     private static extern unsafe void* mpr_sig_release_inst(IntPtr sig, ulong id);
 
+    /// <summary>
+    /// Release the specified signal instance.
+    /// </summary>
+    /// <param name="id">Signal instance to release. Defaults to 0.</param>
     public unsafe void Release(ulong id = 0)
     {
         mpr_sig_release_inst(this.NativePtr, id);


### PR DESCRIPTION
Now that we have a few published bindings I felt it might make sense to include links to them in the README, so I put some badges at the top for quick access to our C#, Python, and Rust bindings.

I did remove the Downloads badge to avoid over-cluttering things, and I wasn't sure how relevant it was anyways? Can definitely bring it back though.