### PR TITLE
Fix leak in List<T>

### DIFF
--- a/include/mapper/mapper_cpp.h
+++ b/include/mapper/mapper_cpp.h
@@ -328,6 +328,52 @@ namespace mapper {
         mpr_time _time;
     };
 
+    template<class T>
+    class ListIter {
+    public:
+        ListIter(mpr_list l) {
+            list = l;
+        }
+
+        T operator*()
+            { return list ? T(*list) : T(NULL); }
+        operator T()
+            { return list ? T(*list) : T(NULL); }
+
+        operator mpr_list() const {
+            return list;
+        }
+
+        ListIter operator++(int) {
+            if (list != nullptr) {
+                auto next = mpr_list_get_next(list);
+                if (next == nullptr) {
+                    mpr_list_free(list);
+                }
+                return ListIter(next);
+            } else {
+                return ListIter((mpr_list)nullptr);
+            }
+        }
+
+        ListIter& operator++() {
+            if (list != nullptr) {
+                auto next = mpr_list_get_next(list);
+                if (next == nullptr) {
+                    mpr_list_free(next);
+                }
+                list = next;
+            }
+            return *this;
+        }
+
+        bool operator==(const ListIter& rhs) const
+            { return (list == rhs.list); }
+
+    private:
+        mpr_list list;
+    };
+
     /*! List objects provide a lazily-computed iterable list of results
      *  from running queries against a mapper::Graph. */
     template <class T>
@@ -339,22 +385,17 @@ namespace mapper {
         using difference_type = int;
         using pointer = int*;
         using reference = int&;
+        using iter = ListIter<T>;
 
         /* Copy constructor */
         List(const List& orig)
-            { _list = mpr_list_get_cpy(orig._list); }
+            { _list = mpr_list_get_cpy(orig._list); printf("list copy made\n"); }
         /* Move constructor */
         List(List&& orig) noexcept
             { _list = orig._list; orig._list = NULL; }
-        /* Copy assignment operator */
-        List& operator=(const List& orig) noexcept
-            { _list = mpr_list_get_cpy(orig._list); return *this; }
-        /* Move assignment operator */
-        List& operator=(List&& orig) noexcept
-            { _list = orig._list; orig._list = NULL; return *this; }
 
         ~List()
-            { mpr_list_free(_list); }
+            { if(_list == nullptr) {return;} mpr_list_free(_list); printf("list freed\n"); }
 
         operator mpr_list() { return _list; }
 
@@ -362,14 +403,11 @@ namespace mapper {
             { return (_list == rhs._list); }
         bool operator!=(const List& rhs)
             { return (_list != rhs._list); }
-        List& operator++()
-            { if (_list) _list = mpr_list_get_next(_list); RETURN_SELF; }
-        List operator++(int)
-            { List tmp(*this); operator++(); return tmp; }
-        List& begin()
-            { RETURN_SELF; }
-        List end()
-            { return List(0); }
+
+        iter begin()
+            { return ListIter<T>(_list); }
+        iter end()
+            { return ListIter<T>((mpr_list)nullptr); }
 
         /*! Return the number of items in a List
          *  \return             The number of items in this list. */
@@ -483,7 +521,7 @@ namespace mapper {
         friend class PropVal;
 
         List(mpr_list list)
-            { _list = list; }
+            { _list = list; printf("list constructed\n");}
     private:
         mpr_list _list;
     };
@@ -1902,7 +1940,7 @@ namespace mapper {
         std::string iface() const
         {
             const char *iface = mpr_graph_get_interface(_obj);
-            return iface ? std::string(iface) : 0;
+            return std::string(iface);
         }
 
         /*! Specify the multicast group and port to use.
@@ -2097,7 +2135,7 @@ namespace mapper {
         operator std::string() const
         {
             if (!val.ptr || !len || type != MPR_STR)
-                return NULL;
+                return std::string();
             return std::string(len > 1 ? *(const char**)val.ptr : val.str);
         }
         operator void*() const

--- a/include/mapper/mapper_cpp.h
+++ b/include/mapper/mapper_cpp.h
@@ -389,13 +389,13 @@ namespace mapper {
 
         /* Copy constructor */
         List(const List& orig)
-            { _list = mpr_list_get_cpy(orig._list); printf("list copy made\n"); }
+            { _list = mpr_list_get_cpy(orig._list); }
         /* Move constructor */
         List(List&& orig) noexcept
             { _list = orig._list; orig._list = NULL; }
 
         ~List()
-            { if(_list == nullptr) {return;} mpr_list_free(_list); printf("list freed\n"); }
+            { if(_list == nullptr) {return;} mpr_list_free(_list); }
 
         operator mpr_list() { return _list; }
 
@@ -521,7 +521,7 @@ namespace mapper {
         friend class PropVal;
 
         List(mpr_list list)
-            { _list = list; printf("list constructed\n");}
+            { _list = list; }
     private:
         mpr_list _list;
     };

--- a/test/testcpp.cpp
+++ b/test/testcpp.cpp
@@ -370,9 +370,8 @@ int main(int argc, char ** argv)
 
     out << "try printing all device signals:" << std::endl;
     List<Signal> qsig = dev.signals(Direction::INCOMING);
-    qsig.begin();
-    for (; qsig != qsig.end(); ++qsig) {
-        out << "  input: " << *qsig << std::endl;
+    for (Signal sig : qsig) {
+        out << "  input: " << sig << std::endl;
     }
 
     Graph graph;
@@ -410,7 +409,7 @@ int main(int argc, char ** argv)
     // try retrieving linked devices
     out << "devices linked to " << dev << ":" << std::endl;
     List<Device> foo = dev[Property::LINKED];
-    for (; foo != foo.end(); foo++) {
+    for (Device dev : foo) {
         out << "  " << *foo << std::endl;
     }
 
@@ -419,8 +418,8 @@ int main(int argc, char ** argv)
     List<Device> qdev = graph.devices();
     qdev.filter(Property::NAME, "my*", Operator::EQUAL);
     qdev.filter(Property::NUM_SIGNALS_IN, 0, Operator::GREATER_THAN_OR_EQUAL);
-    for (; qdev != qdev.end(); qdev++) {
-        out << "  " << *qdev << " (" << (*qdev)[Property::NUM_SIGNALS_IN] << " inputs)" << std::endl;
+    for (Device dev : qdev) {
+        out << "  " << dev << " (" << (dev)[Property::NUM_SIGNALS_IN] << " inputs)" << std::endl;
     }
 
     // check graph records


### PR DESCRIPTION
Fixes a leak in List<T> by iterating over a copy of it, allowing the lifetime of the copy to be more accurately tracked.